### PR TITLE
Fix `copyChat` overriding existing click events

### DIFF
--- a/DSNEforge/src/main/java/com/lilyth/modules/features/copychat/CopyChat.java
+++ b/DSNEforge/src/main/java/com/lilyth/modules/features/copychat/CopyChat.java
@@ -8,6 +8,7 @@ import net.minecraftforge.client.event.ClientChatReceivedEvent;
 public class CopyChat  {
     public void copyChat(ClientChatReceivedEvent e) {
         Minecraft mc = Minecraft.getMinecraft();
+        if (e.message.getChatStyle().getChatClickEvent() != null) return;
         ChatComponentText text = new ChatComponentText(e.message.getUnformattedText());
         text.setChatStyle(e.message.getChatStyle());
         text.getChatStyle().setChatClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, e.message.getUnformattedText()));


### PR DESCRIPTION
before messages like discord links etc. would also get copied into chat but there was no way to actually open these links.